### PR TITLE
add get comments for article API

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -108,3 +108,39 @@ describe("/api", () => {
         });
     });
   });
+
+  describe("/api/articles/:articleId/comments", () => {
+    test("GET:200 sends an array of all comments on the specified article", () => {
+      return request(app)
+        .get("/api/articles/1/comments")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.comments.length).toBe(11);
+          body.comments.forEach((comment) => {
+            expect(typeof comment.comment_id).toBe("number");
+            expect(typeof comment.votes).toBe("number");
+            expect(typeof comment.author).toBe("string");
+            expect(typeof comment.body).toBe("string");
+            expect(typeof comment.created_at).toBe("string");
+            expect(typeof comment.article_id).toBe("number");
+          })
+          expect(body.comments).toBeSortedBy("created_at", { coerce: true });
+        });
+    });
+    test("returns a 404 Not Found when a valid but non-existing id is requested", () => {
+      return request(app)
+        .get("/api/articles/999999/comments")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("No Comments Found");
+        });
+    });
+    test("returns a 400 Bad Request when an invalid id is requested", () => {
+      return request(app)
+        .get("/api/articles/banana/comments")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Bad Request");
+        });
+    });
+  });

--- a/app.js
+++ b/app.js
@@ -2,17 +2,16 @@ const express = require("express");
 
 
 const {getTopics, getEndpoints} = require("./controllers/topics.controller");
-const {getArticle, getAllArticles} = require("./controllers/articles.controller")
+const {getArticle, getAllArticles, getCommentsForArticle} = require("./controllers/articles.controller")
 
 const app = express()
 
 app.get("/api", getEndpoints)
-
 app.get("/api/topics", getTopics);
 
 app.get("/api/articles/:articleId", getArticle)
-
 app.get("/api/articles", getAllArticles)
+app.get("/api/articles/:articleId/comments", getCommentsForArticle)
 
 
 app.use((req, res) => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,4 +1,4 @@
-const { fetchArticle, fetchAllArticles } = require("../models/articles.model");
+const { fetchArticle, fetchAllArticles, fetchCommentsForArticle } = require("../models/articles.model");
 
 exports.getArticle = (req, res, next) => {
     const id = req.params.articleId
@@ -13,6 +13,15 @@ exports.getAllArticles = (req, res, next) => {
     fetchAllArticles()
     .then((articles) => {
         res.status(200).send({articles})
+        })
+        .catch(next);
+}
+
+exports.getCommentsForArticle = (req, res, next) => {
+    const id = req.params.articleId
+    fetchCommentsForArticle(id)
+    .then((comments) => {
+        res.status(200).send({comments})
         })
         .catch(next);
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -40,5 +40,27 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+  "GET /api/articles/:articleId/comments": {
+    "description": "serves an array of all comments on a specified article, default order by date created",
+    "queries":[],
+    "exampleResponse" : [
+      {
+        "comment_id": 5,
+        "body": "I hate streaming noses",
+        "article_id": 1,
+        "author": "icellusedkars",
+        "votes": 0,
+        "created_at": "2020-11-03T21:00:00.000Z"
+      },
+      {
+        "comment_id": 2,
+        "body": "The beautiful thing about treasure is that it exists. Got to find out what kind of sheets these are; not cotton, not rayon, silky.",
+        "article_id": 1,
+        "author": "butter_bridge",
+        "votes": 14,
+        "created_at": "2020-10-31T03:03:00.000Z"
+      }
+    ]
   }
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,20 +1,41 @@
 const db = require("../db/connection");
 
 exports.fetchArticle = (id) => {
-    return db.query(`SELECT * FROM articles WHERE article_id = $1`, [id])
-    .then (({rows}) => {
-        if (rows.length === 0) {return Promise.reject({ status: 404, msg: "Not Found" })}
-        return rows[0]})
-    }
+  return db
+    .query(`SELECT * FROM articles WHERE article_id = $1`, [id])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "Not Found" });
+      }
+      return rows[0];
+    });
+};
 
 exports.fetchAllArticles = () => {
-    return db.query(
-    `SELECT a.author, a.title, a.article_id, a.topic, a.created_at, a.votes, a.article_img_url, COALESCE(COUNT(c.comment_id), 0) AS total_comments
+  return db
+    .query(
+      `SELECT a.author, a.title, a.article_id, a.topic, a.created_at, a.votes, a.article_img_url, COALESCE(COUNT(c.comment_id), 0) AS total_comments
     FROM articles a
     LEFT JOIN comments c ON a.article_id = c.article_id
     GROUP BY a.article_id
-    ORDER BY a.created_at DESC;`)
-    .then(({rows}) => {
-        return rows
-    })
-}
+    ORDER BY a.created_at DESC;`
+    )
+    .then(({ rows }) => {
+      return rows;
+    });
+};
+
+exports.fetchCommentsForArticle = (id) => {
+  return db
+    .query(
+      `SELECT * FROM comments WHERE article_id = $1
+                    ORDER BY created_at DESC;`,
+      [id]
+    )
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "No Comments Found" });
+      }
+      return rows;
+    });
+};


### PR DESCRIPTION
adds an API to allow for pulling all comments against a specified article ID. By default, arranges the comments in date order.

Updates endpoints.json to give an overview of the new endpoint.