### PR TITLE
refactor based on feedback 

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,6 +3,7 @@ const testData = require("../db/data/test-data");
 const db = require("../db/connection");
 const request = require("supertest");
 const app = require("../app");
+const endpoints = require("../endpoints.json")
 
 beforeEach(() => seed(testData));
 afterAll(() => db.end());
@@ -13,7 +14,7 @@ describe("general api errors", () => {
       .get("/api/invalidendpoint")
       .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe("Not Found");
+        expect(body.msg).toBe("Route Not Found");
       });
   });
 });
@@ -24,8 +25,8 @@ describe("/api/topics", () => {
       .get("/api/topics")
       .expect(200)
       .then(({ body }) => {
-        expect(body.length).toBe(3);
-        body.forEach((topic) => {
+        expect(body.topics.length).toBe(3);
+        body.topics.forEach((topic) => {
           expect(typeof topic.slug).toBe("string");
           expect(typeof topic.description).toBe("string");
         });
@@ -39,13 +40,7 @@ describe("/api", () => {
       .get("/api")
       .expect(200)
       .then(({body}) => {
-        for (const endpointName in body.endpoints) {
-          const endpoint = body.endpoints[endpointName]
-          expect(typeof endpoint.description).toBe("string");
-          if(endpoint.exampleResponse) {expect(typeof endpoint.exampleResponse).toBe("object");}
-          if(endpoint.queries) {expect(typeof endpoint.queries).toBe("object");}
-          if(endpoint.bodyFormat) {expect(typeof endpoint.bodyFormat).toBe("object")}
-          }
+        expect(body.endpoints).toEqual(endpoints)
         });
       });
   });
@@ -104,7 +99,7 @@ describe("/api", () => {
             expect(typeof article.article_img_url).toBe("string");
             expect(typeof article.total_comments).toBe("string");
           })
-          expect(body.articles).toBeSortedBy("created_at", { coerce: true });
+          expect(body.articles).toBeSortedBy("created_at", { coerce: true, descending: true });
         });
     });
   });
@@ -124,7 +119,7 @@ describe("/api", () => {
             expect(typeof comment.created_at).toBe("string");
             expect(typeof comment.article_id).toBe("number");
           })
-          expect(body.comments).toBeSortedBy("created_at", { coerce: true });
+          expect(body.comments).toBeSortedBy("created_at", { coerce: true, descending: true });
         });
     });
     test("returns a 404 Not Found when a valid but non-existing id is requested", () => {

--- a/app.js
+++ b/app.js
@@ -14,9 +14,9 @@ app.get("/api/articles", getAllArticles)
 app.get("/api/articles/:articleId/comments", getCommentsForArticle)
 
 
-app.use((req, res) => {
-    res.status(404).send({ msg: "Not Found" });
-  });
+app.all('*', (req, res) => {
+  res.status(404).send({msg: "Route Not Found"})
+    })
 
 app.use((err, req, res, next) => {
     if (err.status && err.msg) {

--- a/controllers/topics.controller.js
+++ b/controllers/topics.controller.js
@@ -4,7 +4,7 @@ const { fetchTopics, fetchEndpoints } = require("../models/topics.model");
 exports.getTopics = (req, res, next) => {
     fetchTopics()
     .then((topics) => {
-      res.status(200).send(topics)
+      res.status(200).send({topics})
     })
     .catch(next);
 };


### PR DESCRIPTION
Updated getTopics to send back as an object with the key of Topics

Updated 404 error handling to use app.all and provide specific "route not found" error message

Updated endpoint test to check against endpoint file directly rather than checking type of elements

Updated test for getting all articles and articles by comments to explicitly test that sorting is in descending order