### PR TITLE
12-get-articles-comment-count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -56,9 +56,28 @@ describe("/api/articles/:article_id", () => {
       votes: 100,
       article_img_url:
         "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+      total_comments: 11
     };
     return request(app)
       .get("/api/articles/1")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.article).toMatchObject(result);
+      });
+  });
+  test("GET:200 works on an article with no comments", () => {
+    const result = {
+      title: "Sony Vaio; or, The Laptop",
+      topic: "mitch",
+      author: "icellusedkars",
+      body: "Call me Mitchell. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would buy a laptop about a little and see the codey part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to coding as soon as I can. This is my substitute for pistol and ball. With a philosophical flourish Cato throws himself upon his sword; I quietly take to the laptop. There is nothing surprising in this. If they but knew it, almost all men in their degree, some time or other, cherish very nearly the same feelings towards the the Vaio with me.",
+      created_at: "2020-10-16T05:03:00.000Z",
+      article_img_url:
+        "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+      total_comments: 0
+    };
+    return request(app)
+      .get("/api/articles/2")
       .expect(200)
       .then(({ body }) => {
         expect(body.article).toMatchObject(result);
@@ -97,7 +116,7 @@ describe("/api/articles", () => {
           expect(typeof article.created_at).toBe("string");
           expect(typeof article.votes).toBe("number");
           expect(typeof article.article_img_url).toBe("string");
-          expect(typeof article.total_comments).toBe("string");
+          expect(typeof article.total_comments).toBe("number");
         });
         expect(body.articles).toBeSortedBy("created_at", {
           coerce: true,
@@ -119,7 +138,7 @@ describe("/api/articles", () => {
           expect(typeof article.created_at).toBe("string");
           expect(typeof article.votes).toBe("number");
           expect(typeof article.article_img_url).toBe("string");
-          expect(typeof article.total_comments).toBe("string");
+          expect(typeof article.total_comments).toBe("number");
         });
         expect(body.articles).toBeSortedBy("created_at", {
           coerce: true,

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,7 +10,7 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles, default order by date created",
+    "description": "serves an array of all articles, default order by date created including a total number of comments",
     "queries": ["author", "topic", "sort_by", "order"],
     "exampleResponse": {
       "articles": [
@@ -21,13 +21,13 @@
           "body": "Text from the article..",
           "created_at": "2018-05-30T15:59:13.341Z",
           "votes": 0,
-          "comment_count": 6
+          "total_comments": 6
         }
       ]
     }
   },
   "GET /api/articles/:articleId": {
-    "description": "serves an object of the requested article by article Id",
+    "description": "serves an object of the requested article by article Id including a total number of comments",
     "queries": [],
     "exampleResponse": {
       "article": {
@@ -37,7 +37,8 @@
         "body": "I find this existence challenging",
         "created_at": "2020-07-09T20:11:00.000Z",
         "votes": 100,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "total_comments": 11
       }
     }
   },

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -2,7 +2,11 @@ const db = require("../db/connection");
 
 exports.fetchArticle = (id) => {
   return db
-    .query(`SELECT * FROM articles WHERE article_id = $1`, [id])
+    .query(`SELECT a.*, CAST(COUNT(c.comment_id) AS INTEGER) AS total_comments
+    FROM articles a
+    LEFT JOIN comments c ON a.article_id = c.article_id
+    WHERE a.article_id = $1
+    GROUP BY a.article_id;`, [id])
     .then(({ rows }) => {
       if (rows.length === 0) {
         return Promise.reject({ status: 404, msg: "Not Found" });
@@ -19,7 +23,7 @@ exports.fetchAllArticles = (query) => {
     return Promise.reject({ status: 400, msg: "Bad Request" });
   }
   
-  const queryString = `SELECT a.author, a.title, a.article_id, a.topic, a.created_at, a.votes, a.article_img_url, COALESCE(COUNT(c.comment_id), 0) AS total_comments
+  const queryString = `SELECT a.author, a.title, a.article_id, a.topic, a.created_at, a.votes, a.article_img_url, CAST(COUNT(c.comment_id) AS INTEGER) AS total_comments
     FROM articles a
     LEFT JOIN comments c ON a.article_id = c.article_id`;
   


### PR DESCRIPTION
Adds functionality to getting articles by ID to show the number of total comments on that article.

Modified get articles to use consistent cast as number to receive the output in correct format

Updated endpoints.json to reflect new functions